### PR TITLE
Add draggable tag reordering in settings groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freshtab-vue",
-  "version": "1.0.6",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freshtab-vue",
-      "version": "1.0.6",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "@vitejs/plugin-vue": "^5.2.4",
@@ -15,7 +15,8 @@
         "pinia": "^3.0.3",
         "vite": "^6.3.5",
         "vue": "^3.5.16",
-        "vue-i18n": "^10.0.8"
+        "vue-i18n": "^10.0.8",
+        "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
         "@types/chrome": "^0.1.1",
@@ -2339,6 +2340,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2789,6 +2796,18 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "pinia": "^3.0.3",
     "vite": "^6.3.5",
     "vue": "^3.5.16",
-    "vue-i18n": "^10.0.8"
+    "vue-i18n": "^10.0.8",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.1",

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -182,7 +182,17 @@
           </div>
 
           <div class="groups-list">
-            <div v-for="group in tagGroups" :key="group.id" class="group-item">
+            <div
+              v-for="group in tagGroups"
+              :key="group.id"
+              :class="[
+                'group-item',
+                {
+                  'group-item--drag-source': draggingGroupId === group.id,
+                  'group-item--drag-target': dragOverGroupId === group.id && draggingGroupId !== group.id
+                }
+              ]"
+            >
               <div class="group-header">
                 <div class="group-info">
                   <span class="group-emoji">{{ group.emoji }}</span>
@@ -207,25 +217,52 @@
               <div class="group-color-preview" :style="{ backgroundColor: group.themeColor }"></div>
 
               <!-- 标签列表显示 -->
-              <div v-if="Array.isArray(group.tags) && group.tags.length > 0" class="tags-list">
-                <div v-for="tag in group.tags" :key="tag.id" class="tag-list-item">
-                  <div class="tag-list-icon">
-                    <span v-if="tag.iconType === 'emoji'">{{ tag.iconValue }}</span>
-                    <span v-else-if="tag.iconType === 'text'">{{ tag.iconValue }}</span>
-                    <img v-else-if="tag.iconType === 'favicon'" :src="getFaviconUrl(tag.url,tag)" :alt="tag.name"
-                      @error="($event.target as HTMLImageElement).style.display = 'none'" />
-                    <span v-else>🔗</span>
-                  </div>
-                  <span class="tag-list-name">{{ tag.name }}</span>
-                  <div class="tag-list-actions">
-                    <button @click="editTagModal(group.id, tag)" class="edit-btn" :title="t('common.edit')">
-                      <Pencil :size="14" />
-                    </button>
-                    <button @click="deleteTagConfirm(group.id, tag.id)" class="delete-btn" :title="t('common.delete')">
-                      <Trash2 :size="14" />
-                    </button>
-                  </div>
-                </div>
+              <div v-if="hasTags(group)" class="tags-list">
+                <draggable
+                  :list="group.tags"
+                  item-key="id"
+                  tag="div"
+                  class="tags-draggable"
+                  :group="TAG_DRAG_GROUP"
+                  handle=".tag-drag-handle"
+                  ghost-class="tag-list-item--ghost"
+                  chosen-class="tag-list-item--chosen"
+                  drag-class="tag-list-item--dragging"
+                  @start="handleTagsDragStart(group.id)"
+                  @change="markTagOrderDirty"
+                  @end="handleTagsDragEnd"
+                  @dragenter="handleTagsDragEnter(group.id)"
+                  @dragleave="handleTagsDragLeave(group.id)"
+                >
+                  <template #item="{ element: tag }">
+                    <div class="tag-list-item">
+                      <button
+                        type="button"
+                        class="tag-drag-handle"
+                        :title="t('settings.groups.dragHandle')"
+                        :aria-label="t('settings.groups.dragHandle')"
+                      >
+                        <GripVertical :size="16" />
+                      </button>
+                      <div class="tag-list-icon">
+                        <span v-if="tag.iconType === 'emoji'">{{ tag.iconValue }}</span>
+                        <span v-else-if="tag.iconType === 'text'">{{ tag.iconValue }}</span>
+                        <img v-else-if="tag.iconType === 'favicon'" :src="getFaviconUrl(tag.url,tag)" :alt="tag.name"
+                          @error="($event.target as HTMLImageElement).style.display = 'none'" />
+                        <span v-else>🔗</span>
+                      </div>
+                      <span class="tag-list-name">{{ tag.name }}</span>
+                      <div class="tag-list-actions">
+                        <button @click="editTagModal(group.id, tag)" class="edit-btn" :title="t('common.edit')">
+                          <Pencil :size="14" />
+                        </button>
+                        <button @click="deleteTagConfirm(group.id, tag.id)" class="delete-btn" :title="t('common.delete')">
+                          <Trash2 :size="14" />
+                        </button>
+                      </div>
+                    </div>
+                  </template>
+                </draggable>
 
                 <!-- 添加标签按钮 -->
                 <button @click="addTagModal(group.id)" class="add-tag-button">
@@ -503,6 +540,7 @@ import { useI18n } from 'vue-i18n'
 import { useTagGroupsStore } from '../stores/tagGroupsStore.ts'
 import EmojiPicker from './EmojiPicker.vue'
 import TagModal from './TagModal.vue'
+import draggable from 'vuedraggable'
 import { CURRENT_VERSION } from '../services/version'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useToast } from '../composables/useToast'
@@ -512,6 +550,7 @@ import {
   Clock3,
   FolderKanban,
   Github,
+  GripVertical,
   Image,
   Images,
   Info,
@@ -594,8 +633,12 @@ const showTagModal = ref(false)
 const editingGroupId: Ref<string> = ref('')
 const currentGroupId: Ref<string | null> = ref(null)
 const currentEditingTag: Ref<Tag | null> = ref(null)
+const draggingGroupId: Ref<string | null> = ref(null)
+const dragOverGroupId: Ref<string | null> = ref(null)
+const tagOrderDirty = ref(false)
 const windowWidth = ref(window.innerWidth)
 const fileInput = ref<HTMLInputElement>()
+const TAG_DRAG_GROUP = 'settings-tag-items'
 
 const groupForm = reactive({
   name: '',
@@ -656,6 +699,8 @@ const updateTheme = (theme: string): void => {
 const updateSetting = async (key: string, value: any): Promise<void> => {
   await settingsStore.updateSettings({ [key]: value })
 }
+
+const hasTags = (group: TagGroup): boolean => Array.isArray(group.tags) && group.tags.length > 0
 
 // 分组管理方法
 const editGroupModal = (group: TagGroup): void => {
@@ -735,6 +780,43 @@ const saveTag = async (tagData: Partial<Tag>): Promise<void> => {
 const deleteTagConfirm = async (groupId: string, tagId: string): Promise<void> => {
   await tagGroupsStore.removeTag(groupId, tagId)
 }
+
+const handleTagsDragStart = (groupId: string): void => {
+  draggingGroupId.value = groupId
+  dragOverGroupId.value = groupId
+  tagOrderDirty.value = false
+}
+
+const handleTagsDragEnter = (groupId: string): void => {
+  if (draggingGroupId.value) {
+    dragOverGroupId.value = groupId
+  }
+}
+
+const handleTagsDragLeave = (groupId: string): void => {
+  if (dragOverGroupId.value === groupId && draggingGroupId.value !== groupId) {
+    dragOverGroupId.value = null
+  }
+}
+
+const markTagOrderDirty = (): void => {
+  tagOrderDirty.value = true
+}
+
+const handleTagsDragEnd = async (): Promise<void> => {
+  try {
+    if (tagOrderDirty.value) {
+      await tagGroupsStore.saveGroupsOrder(tagGroupsStore.tagGroups.groups || [])
+    }
+  } catch (error) {
+    console.error(t('settings.groups.saveFailed'), error)
+  } finally {
+    draggingGroupId.value = null
+    dragOverGroupId.value = null
+    tagOrderDirty.value = false
+  }
+}
+
 function getFaviconUrl(url: string, tag: Tag): string {
   // Note: validFaviconUrl is not part of the Tag interface but may exist in runtime
   const tagWithExtras = tag as Tag & { validFaviconUrl?: string }
@@ -1540,6 +1622,16 @@ onMounted(async () => {
   box-shadow: 0 4px 12px rgba(0, 123, 255, 0.1);
 }
 
+.group-item--drag-source {
+  border-color: #6c757d;
+  box-shadow: 0 6px 18px rgba(108, 117, 125, 0.14);
+}
+
+.group-item--drag-target {
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.16), 0 8px 20px rgba(0, 123, 255, 0.12);
+}
+
 .group-header {
   display: flex;
   justify-content: space-between;
@@ -1687,6 +1779,10 @@ onMounted(async () => {
   overflow: hidden;
 }
 
+.tags-draggable {
+  min-height: 0;
+}
+
 .tag-list-item {
   display: flex;
   align-items: center;
@@ -1701,6 +1797,42 @@ onMounted(async () => {
 
 .tag-list-item:hover {
   background-color: #f8f9fa;
+}
+
+.tag-list-item--ghost {
+  opacity: 0.4;
+  background: #e9f2ff;
+}
+
+.tag-list-item--chosen,
+.tag-list-item--dragging {
+  background: #eef5ff;
+}
+
+.tag-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  margin-right: 10px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #adb5bd;
+  cursor: grab;
+  flex-shrink: 0;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.tag-drag-handle:hover {
+  background: #eef2f7;
+  color: #6c757d;
+}
+
+.tag-drag-handle:active {
+  cursor: grabbing;
 }
 
 .tag-list-icon {

--- a/src/i18n/locales/en-US.js
+++ b/src/i18n/locales/en-US.js
@@ -94,6 +94,7 @@ export default {
       themeColor: 'Theme color',
       emptyAddFirstTag: 'Add the first tag',
       tagCount: '{count} tags',
+      dragHandle: 'Drag to reorder',
       saveFailed: 'Failed to save group'
     },
     wallpaper: {

--- a/src/i18n/locales/zh-CN.js
+++ b/src/i18n/locales/zh-CN.js
@@ -94,6 +94,7 @@ export default {
       themeColor: '主题颜色',
       emptyAddFirstTag: '添加第一个标签',
       tagCount: '{count} 个标签',
+      dragHandle: '拖动调整顺序',
       saveFailed: '保存分组失败'
     },
     wallpaper: {

--- a/src/stores/tagGroupsStore.ts
+++ b/src/stores/tagGroupsStore.ts
@@ -7,6 +7,13 @@ import { DEFAULT_LOCALE } from '../i18n';
 export const useTagGroupsStore = defineStore('tagGroups', () => {
   const tagGroups: Ref<TagGroupConfig> = ref({} as TagGroupConfig);
 
+  function cloneGroups(groups: TagGroup[]): TagGroup[] {
+    return groups.map((group) => ({
+      ...group,
+      tags: [...(group.tags || [])]
+    }));
+  }
+
   async function initialize(locale: string = DEFAULT_LOCALE): Promise<void> {
     const data = await getTagGroups(locale);
     tagGroups.value = data;
@@ -22,6 +29,15 @@ export const useTagGroupsStore = defineStore('tagGroups', () => {
   async function updateTagGroups(newTagGroups: TagGroupConfig): Promise<void> {
     tagGroups.value = { ...newTagGroups };
     await setTagGroups(tagGroups.value);
+  }
+
+  async function saveGroupsOrder(groups: TagGroup[]): Promise<void> {
+    const updatedTagGroups: TagGroupConfig = {
+      ...tagGroups.value,
+      groups: cloneGroups(groups)
+    };
+
+    await updateTagGroups(updatedTagGroups);
   }
 
   async function addGroup(group: Partial<TagGroup>): Promise<TagGroup> {
@@ -169,6 +185,7 @@ export const useTagGroupsStore = defineStore('tagGroups', () => {
   return {
     tagGroups,
     initialize,
+    saveGroupsOrder,
     addGroup,
     updateGroup,
     removeGroup,

--- a/src/test/tagGroupsPersistence.test.js
+++ b/src/test/tagGroupsPersistence.test.js
@@ -184,4 +184,94 @@ describe('tag groups persistence', () => {
     app.unmount()
     root.remove()
   })
+
+  it('persists reordered tags within the same group', async () => {
+    const { chrome, storageData } = createChromeStorageMock()
+    global.chrome = chrome
+
+    const { useTagGroupsStore } = await loadStores()
+
+    setActivePinia(createPinia())
+    const store = useTagGroupsStore()
+    await store.initialize()
+
+    const groups = store.tagGroups.groups.map((group) => ({
+      ...group,
+      tags: [...group.tags]
+    }))
+
+    const defaultGroup = groups.find((group) => group.id === 'default')
+    defaultGroup.tags = [
+      defaultGroup.tags[1],
+      defaultGroup.tags[2],
+      defaultGroup.tags[0]
+    ]
+
+    await store.saveGroupsOrder(groups)
+
+    const savedGroups = JSON.parse(storageData.sync.FRESH_TAB_TAG_GROUPS)
+    expect(savedGroups.groups.find((group) => group.id === 'default').tags.map((tag) => tag.id)).toEqual([
+      'github',
+      'sto',
+      'google'
+    ])
+
+    setActivePinia(createPinia())
+    const reloadedStore = useTagGroupsStore()
+    await reloadedStore.initialize()
+
+    expect(reloadedStore.tagGroups.groups.find((group) => group.id === 'default').tags.map((tag) => tag.id)).toEqual([
+      'github',
+      'sto',
+      'google'
+    ])
+  })
+
+  it('persists moving a tag to another group', async () => {
+    const { chrome, storageData } = createChromeStorageMock()
+    global.chrome = chrome
+
+    const { useTagGroupsStore } = await loadStores()
+
+    setActivePinia(createPinia())
+    const store = useTagGroupsStore()
+    await store.initialize()
+
+    const groups = store.tagGroups.groups.map((group) => ({
+      ...group,
+      tags: [...group.tags]
+    }))
+
+    const sourceGroup = groups.find((group) => group.id === 'default')
+    const targetGroup = groups.find((group) => group.id === 'dev_tools')
+    const [movedTag] = sourceGroup.tags.splice(0, 1)
+    targetGroup.tags.splice(1, 0, movedTag)
+
+    await store.saveGroupsOrder(groups)
+
+    const savedGroups = JSON.parse(storageData.sync.FRESH_TAB_TAG_GROUPS)
+    expect(savedGroups.groups.find((group) => group.id === 'default').tags.map((tag) => tag.id)).toEqual([
+      'github',
+      'sto'
+    ])
+    expect(savedGroups.groups.find((group) => group.id === 'dev_tools').tags.map((tag) => tag.id)).toEqual([
+      'vacode',
+      'google',
+      'npm'
+    ])
+
+    setActivePinia(createPinia())
+    const reloadedStore = useTagGroupsStore()
+    await reloadedStore.initialize()
+
+    expect(reloadedStore.tagGroups.groups.find((group) => group.id === 'default').tags.map((tag) => tag.id)).toEqual([
+      'github',
+      'sto'
+    ])
+    expect(reloadedStore.tagGroups.groups.find((group) => group.id === 'dev_tools').tags.map((tag) => tag.id)).toEqual([
+      'vacode',
+      'google',
+      'npm'
+    ])
+  })
 })


### PR DESCRIPTION
## Summary
- Add `vuedraggable` to the project and wire it into the settings modal tag lists.
- Support drag handles for reordering tags within a group and moving tags between groups.
- Persist drag results immediately through the tag groups store so the homepage reflects the new order on reload.
- Add lightweight UI feedback and localized drag-handle text.

## Testing
- Added persistence coverage for same-group reordering and cross-group tag moves.
- Verified the updated tag-group persistence tests pass.
- Verified the production build completes successfully.